### PR TITLE
feat(db): link auth.users ↔ public.users with FK + triggers (default org   fallback)

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,11 @@
     "start": "next start",
     "lint": "eslint",
     "db:generate": "drizzle-kit generate",
-    "db:studio": "drizzle-kit studio"
+    "db:studio": "drizzle-kit studio",
+    "db:apply:link": "node scripts/run-sql.mjs scripts/sql/link_auth_public_users.sql",
+    "db:apply:backfill": "node scripts/run-sql.mjs scripts/sql/backfill_public_users.sql",
+    "db:check:latest": "node scripts/query-sql.mjs scripts/sql/check_latest_link.sql",
+    "db:check:counts": "node scripts/query-sql.mjs scripts/sql/check_counts.sql"
   },
   "dependencies": {
     "@supabase/ssr": "^0.7.0",

--- a/scripts/query-sql.mjs
+++ b/scripts/query-sql.mjs
@@ -1,0 +1,50 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import dotenv from 'dotenv';
+import pg from 'pg';
+
+const cwd = process.cwd();
+const envFile = path.join(cwd, '.env');
+const envLocal = path.join(cwd, '.env.local');
+if (fs.existsSync(envFile)) dotenv.config({ path: envFile });
+if (fs.existsSync(envLocal)) dotenv.config({ path: envLocal, override: true });
+
+const file = process.argv[2];
+if (!file) {
+  console.error('Usage: node scripts/query-sql.mjs <sql-file>');
+  process.exit(1);
+}
+
+const sqlPath = path.resolve(file);
+if (!fs.existsSync(sqlPath)) {
+  console.error('SQL file not found:', sqlPath);
+  process.exit(1);
+}
+
+const databaseUrl = process.env.DATABASE_URL;
+if (!databaseUrl) {
+  console.error('DATABASE_URL is not set in env');
+  process.exit(1);
+}
+
+const sqlText = fs.readFileSync(sqlPath, 'utf8');
+
+const { Client } = pg;
+const client = new Client({ connectionString: databaseUrl, ssl: { rejectUnauthorized: false } });
+
+async function main() {
+  await client.connect();
+  try {
+    const res = await client.query(sqlText);
+    console.log(JSON.stringify(res.rows, null, 2));
+  } catch (err) {
+    console.error('Error running query:', err.message);
+    process.exitCode = 1;
+  } finally {
+    await client.end();
+  }
+}
+
+main();
+

--- a/scripts/run-sql.mjs
+++ b/scripts/run-sql.mjs
@@ -1,0 +1,54 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import dotenv from 'dotenv';
+import pg from 'pg';
+
+// Load env (prefer .env.local if present)
+const cwd = process.cwd();
+const envLocal = path.join(cwd, '.env.local');
+const envFile = path.join(cwd, '.env');
+// Load .env first, then override with .env.local if present
+if (fs.existsSync(envFile)) dotenv.config({ path: envFile });
+if (fs.existsSync(envLocal)) dotenv.config({ path: envLocal, override: true });
+
+const file = process.argv[2];
+if (!file) {
+  console.error('Usage: node scripts/run-sql.mjs <sql-file>');
+  process.exit(1);
+}
+
+const sqlPath = path.resolve(file);
+if (!fs.existsSync(sqlPath)) {
+  console.error('SQL file not found:', sqlPath);
+  process.exit(1);
+}
+
+const databaseUrl = process.env.DATABASE_URL;
+if (!databaseUrl) {
+  console.error('DATABASE_URL is not set in env');
+  process.exit(1);
+}
+
+const sqlText = fs.readFileSync(sqlPath, 'utf8');
+
+const { Client } = pg;
+const client = new Client({ connectionString: databaseUrl, ssl: { rejectUnauthorized: false } });
+
+async function main() {
+  await client.connect();
+  try {
+    await client.query('begin');
+    await client.query(sqlText);
+    await client.query('commit');
+    console.log('Applied:', path.basename(sqlPath));
+  } catch (err) {
+    await client.query('rollback');
+    console.error('Error applying SQL:', err.message);
+    process.exitCode = 1;
+  } finally {
+    await client.end();
+  }
+}
+
+main();

--- a/scripts/sql/backfill_public_users.sql
+++ b/scripts/sql/backfill_public_users.sql
@@ -1,0 +1,35 @@
+-- Backfill public.users from auth.users
+-- Default behavior: only rows where org_id exists in metadata
+
+insert into public.users (id, org_id, name, role)
+select u.id,
+       coalesce((u.raw_user_meta_data->>'org_id')::uuid,
+                '9b4944e1-5f14-424b-b7ab-c89e3f3c17c6'::uuid) as org_id,
+       coalesce(u.raw_user_meta_data->>'name', u.email) as name,
+       coalesce(u.raw_user_meta_data->>'role', 'staff') as role
+from auth.users u
+left join public.users p on p.id = u.id
+where p.id is null;
+
+-- Optional: previous strict variant (org_id required)
+-- insert into public.users (id, org_id, name, role)
+-- select u.id,
+--        coalesce((u.user_metadata->>'org_id')::uuid,
+--                 (u.raw_user_meta_data->>'org_id')::uuid) as org_id,
+--        coalesce(u.user_metadata->>'name', u.raw_user_meta_data->>'name', u.email) as name,
+--        coalesce(u.user_metadata->>'role', u.raw_user_meta_data->>'role', 'staff') as role
+-- from auth.users u
+-- left join public.users p on p.id = u.id
+-- where p.id is null
+--   and coalesce((u.user_metadata->>'org_id')::uuid, (u.raw_user_meta_data->>'org_id')::uuid) is not null;
+
+-- Update existing names/roles from metadata
+update public.users p
+set name = coalesce(u.raw_user_meta_data->>'name', u.email),
+    role = coalesce(u.raw_user_meta_data->>'role', p.role)
+from auth.users u
+where p.id = u.id;
+
+-- Inspect users missing org_id in metadata
+-- select id, email from auth.users
+-- where (raw_user_meta_data->>'org_id') is null;

--- a/scripts/sql/check_counts.sql
+++ b/scripts/sql/check_counts.sql
@@ -1,0 +1,6 @@
+select
+  (select count(*) from auth.users) as auth_count,
+  (select count(*) from public.users) as public_count,
+  (select count(*) from public.users u left join auth.users a on a.id = u.id where a.id is null) as public_orphans,
+  (select count(*) from auth.users a left join public.users u on u.id = a.id where u.id is null) as auth_missing_public;
+

--- a/scripts/sql/check_latest_link.sql
+++ b/scripts/sql/check_latest_link.sql
@@ -1,0 +1,18 @@
+with latest as (
+  select id, email, raw_user_meta_data, created_at
+  from auth.users
+  order by created_at desc
+  limit 5
+)
+select
+  a.id as auth_id,
+  a.email,
+  a.raw_user_meta_data,
+  p.org_id,
+  p.name,
+  p.role,
+  p.created_at as public_created_at
+from latest a
+left join public.users p on p.id = a.id
+order by a.created_at desc;
+

--- a/scripts/sql/link_auth_public_users.sql
+++ b/scripts/sql/link_auth_public_users.sql
@@ -1,0 +1,112 @@
+-- Link auth.users ↔ public.users
+-- Requirements: public.users.id = auth.users.id, FK on delete cascade,
+--               signup/update trigger, initial backfill handled separately.
+-- Run this in Supabase SQL Editor or via the provided Node runner.
+
+-- 1) FK from public.users(id) → auth.users(id) with ON DELETE CASCADE
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.table_constraints c
+    where c.constraint_schema = 'public'
+      and c.table_name = 'users'
+      and c.constraint_name = 'users_id_auth_users_id_fk'
+  ) then
+    alter table public.users
+      add constraint users_id_auth_users_id_fk
+      foreign key (id) references auth.users(id) on delete cascade;
+  end if;
+end$$;
+
+-- Ensure default org exists (idempotent)
+insert into public.orgs (id, name)
+values ('9b4944e1-5f14-424b-b7ab-c89e3f3c17c6', 'Default')
+on conflict (id) do nothing;
+
+-- 2) Trigger function (default-org injection when org_id missing)
+create or replace function public.sync_user_from_auth()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_org  uuid;
+  v_name text;
+  v_role text;
+begin
+  -- Use raw_user_meta_data only for compatibility
+  v_org  := coalesce((new.raw_user_meta_data->>'org_id')::uuid,
+                     '9b4944e1-5f14-424b-b7ab-c89e3f3c17c6'::uuid);
+  v_name := coalesce(new.raw_user_meta_data->>'name', new.email);
+  v_role := coalesce(new.raw_user_meta_data->>'role', 'staff');
+
+  insert into public.users (id, org_id, name, role)
+  values (new.id, v_org, v_name, v_role)
+  on conflict (id) do update
+    set org_id = coalesce(excluded.org_id, public.users.org_id),
+        name   = excluded.name,
+        role   = coalesce(excluded.role, public.users.role);
+  return new;
+end$$;
+
+-- Alternative 1) Default-org injection (uncomment + set UUID)
+-- create or replace function public.sync_user_from_auth()
+-- returns trigger
+-- language plpgsql security definer set search_path = public as $$
+-- declare
+--   v_org  uuid;
+--   v_name text;
+--   v_role text;
+-- begin
+--   v_org  := coalesce((new.user_metadata->>'org_id')::uuid,
+--                      (new.raw_user_meta_data->>'org_id')::uuid,
+--                      '<DEFAULT_ORG_UUID>'::uuid);
+--   v_name := coalesce(new.user_metadata->>'name', new.raw_user_meta_data->>'name', new.email);
+--   v_role := coalesce(new.user_metadata->>'role', new.raw_user_meta_data->>'role', 'staff');
+--   insert into public.users (id, org_id, name, role)
+--   values (new.id, v_org, v_name, v_role)
+--   on conflict (id) do update
+--     set org_id = coalesce(excluded.org_id, public.users.org_id),
+--         name   = excluded.name,
+--         role   = coalesce(excluded.role, public.users.role);
+--   return new;
+-- end$$;
+
+-- Alternative 2) Error when org_id missing (enforce metadata)
+-- create or replace function public.sync_user_from_auth()
+-- returns trigger
+-- language plpgsql security definer set search_path = public as $$
+-- declare
+--   v_org  uuid := coalesce((new.user_metadata->>'org_id')::uuid,
+--                           (new.raw_user_meta_data->>'org_id')::uuid);
+--   v_name text := coalesce(new.user_metadata->>'name', new.raw_user_meta_data->>'name', new.email);
+--   v_role text := coalesce(new.user_metadata->>'role', new.raw_user_meta_data->>'role', 'staff');
+-- begin
+--   if v_org is null then
+--     raise exception 'org_id is required in user metadata';
+--   end if;
+--   insert into public.users (id, org_id, name, role)
+--   values (new.id, v_org, v_name, v_role)
+--   on conflict (id) do update
+--     set org_id = coalesce(excluded.org_id, public.users.org_id),
+--         name   = excluded.name,
+--         role   = coalesce(excluded.role, public.users.role);
+--   return new;
+-- end$$;
+
+-- 3) Create/replace trigger on auth.users
+do $$
+begin
+  if exists (
+    select 1 from pg_trigger t
+    join pg_class c on c.oid = t.tgrelid
+    join pg_namespace n on n.oid = c.relnamespace
+    where n.nspname = 'auth' and c.relname = 'users' and t.tgname = 'tr_sync_user_from_auth'
+  ) then
+    drop trigger tr_sync_user_from_auth on auth.users;
+  end if;
+  create trigger tr_sync_user_from_auth
+  after insert or update on auth.users
+  for each row execute function public.sync_user_from_auth();
+end$$;

--- a/src/lib/drizzle/migrations/0003_auth_public_users_link.sql
+++ b/src/lib/drizzle/migrations/0003_auth_public_users_link.sql
@@ -1,0 +1,69 @@
+-- Link public.users.id ↔ auth.users.id with FK (cascade) and sync triggers
+-- Requirements: public.users.id = auth.users.id, FK on delete cascade,
+--               signup/update triggers, initial backfill handled separately.
+
+-- 1) Add FK from public.users(id) → auth.users(id) with ON DELETE CASCADE (idempotent)
+do $$
+begin
+  if not exists (
+    select 1
+    from information_schema.table_constraints c
+    where c.constraint_schema = 'public'
+      and c.table_name = 'users'
+      and c.constraint_name = 'users_id_auth_users_id_fk'
+  ) then
+    alter table public.users
+      add constraint users_id_auth_users_id_fk
+      foreign key (id) references auth.users(id) on delete cascade;
+  end if;
+end$$;
+
+-- Ensure default org exists (idempotent)
+insert into public.orgs (id, name)
+values ('9b4944e1-5f14-424b-b7ab-c89e3f3c17c6', 'Default')
+on conflict (id) do nothing;
+
+create or replace function public.sync_user_from_auth()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_org  uuid;
+  v_name text;
+  v_role text;
+begin
+  -- Use raw_user_meta_data and default to the given org when missing
+  v_org  := coalesce((new.raw_user_meta_data->>'org_id')::uuid,
+                     '9b4944e1-5f14-424b-b7ab-c89e3f3c17c6'::uuid);
+  v_name := coalesce(new.raw_user_meta_data->>'name', new.email);
+  v_role := coalesce(new.raw_user_meta_data->>'role', 'staff');
+
+  insert into public.users (id, org_id, name, role)
+  values (new.id, v_org, v_name, v_role)
+  on conflict (id) do update
+    set org_id = coalesce(excluded.org_id, public.users.org_id),
+        name   = excluded.name,
+        role   = coalesce(excluded.role, public.users.role);
+  return new;
+end$$;
+
+-- 3) Create trigger on auth.users for INSERT/UPDATE (idempotent)
+do $$
+begin
+  if exists (
+    select 1 from pg_trigger t
+    join pg_class c on c.oid = t.tgrelid
+    join pg_namespace n on n.oid = c.relnamespace
+    where n.nspname = 'auth' and c.relname = 'users' and t.tgname = 'tr_sync_user_from_auth'
+  ) then
+    drop trigger tr_sync_user_from_auth on auth.users;
+  end if;
+
+  create trigger tr_sync_user_from_auth
+  after insert or update on auth.users
+  for each row execute function public.sync_user_from_auth();
+end$$;
+
+-- Note: Deletion is handled by FK ON DELETE CASCADE; no delete trigger required.


### PR DESCRIPTION
- Add FK public.users(id) → auth.users(id) ON DELETE CASCADE
- Trigger on auth.users INSERT/UPDATE → upsert into public.users
 - Default org injection when org_id missing: 9b4944e1-5f14-424b-b7ab-c89e3f3c17c6
- Add scripts: link/backfill/check + Node runners (pnpm db:apply:link, pnpm db:apply:backfill, pnpm db:check:*)
- Backfill kept as operational script (not a migration)
- Verified with counts/latest checks; no new env committed