### PR TITLE
feat(auth): ensure email confirmation uses callback flow

### DIFF
--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from "next/server";
+import { supabaseServer } from "@/lib/supabase/server";
+
+function resolveNextPath(rawNext: string | null | undefined): string {
+  if (!rawNext) return "/leads";
+  if (!rawNext.startsWith("/")) return "/leads";
+  return rawNext;
+}
+
+export async function GET(request: Request) {
+  const requestUrl = new URL(request.url);
+  const code = requestUrl.searchParams.get("code");
+  const next = resolveNextPath(requestUrl.searchParams.get("next"));
+
+  if (!code) {
+    return NextResponse.redirect(new URL("/login?error=missing_code", requestUrl.origin));
+  }
+
+  try {
+    const supabase = await supabaseServer();
+    const { error } = await supabase.auth.exchangeCodeForSession(code);
+    if (error) {
+      console.error("[auth/callback] session exchange failed", error);
+      return NextResponse.redirect(
+        new URL("/login?error=exchange_failed", requestUrl.origin)
+      );
+    }
+  } catch (error) {
+    console.error("[auth/callback] unexpected error", error);
+    return NextResponse.redirect(
+      new URL("/login?error=exchange_exception", requestUrl.origin)
+    );
+  }
+
+  return NextResponse.redirect(new URL(next, requestUrl.origin));
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,103 +1,24 @@
-import Image from "next/image";
+import { redirect } from "next/navigation";
 
-export default function Home() {
-  return (
-    <div className="font-sans grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20">
-      <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={180}
-          height={38}
-          priority
-        />
-        <ol className="font-mono list-inside list-decimal text-sm/6 text-center sm:text-left">
-          <li className="mb-2 tracking-[-.01em]">
-            Get started by editing{" "}
-            <code className="bg-black/[.05] dark:bg-white/[.06] font-mono font-semibold px-1 py-0.5 rounded">
-              src/app/page.tsx
-            </code>
-            .
-          </li>
-          <li className="tracking-[-.01em]">
-            Save and see your changes instantly.
-          </li>
-        </ol>
+type SearchParams = Record<string, string | string[] | undefined>;
 
-        <div className="flex gap-4 items-center flex-col sm:flex-row">
-          <a
-            className="rounded-full border border-solid border-transparent transition-colors flex items-center justify-center bg-foreground text-background gap-2 hover:bg-[#383838] dark:hover:bg-[#ccc] font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 sm:w-auto"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={20}
-              height={20}
-            />
-            Deploy now
-          </a>
-          <a
-            className="rounded-full border border-solid border-black/[.08] dark:border-white/[.145] transition-colors flex items-center justify-center hover:bg-[#f2f2f2] dark:hover:bg-[#1a1a1a] hover:border-transparent font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 w-full sm:w-auto md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Read our docs
-          </a>
-        </div>
-      </main>
-      <footer className="row-start-3 flex gap-[24px] flex-wrap items-center justify-center">
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/file.svg"
-            alt="File icon"
-            width={16}
-            height={16}
-          />
-          Learn
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/window.svg"
-            alt="Window icon"
-            width={16}
-            height={16}
-          />
-          Examples
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/globe.svg"
-            alt="Globe icon"
-            width={16}
-            height={16}
-          />
-          Go to nextjs.org →
-        </a>
-      </footer>
-    </div>
-  );
+function toUrlSearchParams(searchParams: SearchParams) {
+  const result = new URLSearchParams();
+  for (const [key, value] of Object.entries(searchParams)) {
+    if (typeof value === "string") {
+      result.set(key, value);
+    }
+  }
+  return result;
+}
+
+export default function Home({ searchParams }: { searchParams: SearchParams }) {
+  const code = typeof searchParams.code === "string" ? searchParams.code : undefined;
+  if (code) {
+    const forwarded = toUrlSearchParams(searchParams).toString();
+    const target = forwarded.length > 0 ? `/auth/callback?${forwarded}` : "/auth/callback";
+    redirect(target);
+  }
+
+  redirect("/login");
 }

--- a/src/app/signup/SignupForm.tsx
+++ b/src/app/signup/SignupForm.tsx
@@ -34,10 +34,16 @@ export default function SignupForm({ orgs }: { orgs: SignupOrgOption[] }) {
     }
 
     const supabase = supabaseBrowser();
+    const origin = typeof window !== "undefined" ? window.location.origin : "";
+    const emailRedirectTo = origin
+      ? `${origin}/auth/callback?${new URLSearchParams({ next: "/leads" })}`
+      : undefined;
+
     const { data, error } = await supabase.auth.signUp({
       email,
       password,
       options: {
+        emailRedirectTo,
         data: {
           name,
           org_id: orgId,


### PR DESCRIPTION
- Auth email 링크가 /auth/callback으로 돌아오면 Supabase 세션을 교환해 /leads로 이동시키도록 라우트를 추가
- 회원가입 폼에서 emailRedirectTo를 새 콜백으로 지정해 확인 메일이 올바른 경로로 이동
- 루트 페이지는 더 이상 기본 Next 화면을 보여주지 않고, Supabase 파라미터가 있으면 그대로 콜백에 넘겨 처리한 뒤 기본적으로 /login으로 리다이렉트
- Supabase Auth ↔ public.users 동기화 시나리오 테스트 결과를 TODO.md에 정리