### PR TITLE
사파리 로그인 문제 해결

### DIFF
--- a/src/lib/supabase/browser.ts
+++ b/src/lib/supabase/browser.ts
@@ -1,10 +1,27 @@
 // src/lib/supabase/browser.ts
 import { createBrowserClient } from "@supabase/ssr";
+import { getSupabaseStorage } from "@/lib/supabase/storage";
+
+let browserClient: ReturnType<typeof createBrowserClient> | null = null;
 
 export function supabaseBrowser() {
   console.log("[supabaseBrowser] URL=", process.env.NEXT_PUBLIC_SUPABASE_URL, " KEY?", !!process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY);
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
   const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
   if (!url || !key) throw new Error("Missing NEXT_PUBLIC_SUPABASE_URL or NEXT_PUBLIC_SUPABASE_ANON_KEY");
-  return createBrowserClient(url, key);
+  if (browserClient) return browserClient;
+
+  // Safari(특히 시크릿 모드)에서 localStorage 접근이 거부되는 경우가 있어
+  // 스토리지를 안전하게 감싸준다. (쿠키 → 메모리 순으로 대체)
+  const storage = getSupabaseStorage();
+  browserClient = createBrowserClient(url, key, {
+    auth: {
+      storage,
+      autoRefreshToken: true,
+      persistSession: true,
+      detectSessionInUrl: true,
+    },
+  });
+
+  return browserClient;
 }

--- a/src/lib/supabase/storage.ts
+++ b/src/lib/supabase/storage.ts
@@ -1,0 +1,57 @@
+// src/lib/supabase/storage.ts
+// Provide a storage adapter that survives Safari quirks (Private mode / ITP) by
+// gracefully falling back when localStorage is unavailable.
+// Implements the minimal Storage interface used by supabase-js.
+
+type StorageAdapter = Pick<Storage, "getItem" | "setItem" | "removeItem">;
+
+function isLocalStorageUsable(): boolean {
+  if (typeof window === "undefined" || !window.localStorage) return false;
+  try {
+    const key = "__sb_test__";
+    window.localStorage.setItem(key, "1");
+    window.localStorage.removeItem(key);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function cookieStorage(): StorageAdapter {
+  return {
+    getItem(key) {
+      if (typeof document === "undefined") return null;
+      const match = document.cookie.match(new RegExp(`(?:^|; )${encodeURIComponent(key)}=([^;]*)`));
+      return match ? decodeURIComponent(match[1]) : null;
+    },
+    setItem(key, value) {
+      if (typeof document === "undefined") return;
+      // 7-day expiry to balance persistence and token refresh cadence.
+      const expires = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toUTCString();
+      document.cookie = `${encodeURIComponent(key)}=${encodeURIComponent(value)}; Path=/; SameSite=Lax; Expires=${expires}`;
+    },
+    removeItem(key) {
+      if (typeof document === "undefined") return;
+      document.cookie = `${encodeURIComponent(key)}=; Path=/; Max-Age=0; SameSite=Lax`;
+    },
+  };
+}
+
+function memoryStorage(): StorageAdapter {
+  const mem = new Map<string, string>();
+  return {
+    getItem: (key) => mem.get(key) ?? null,
+    setItem: (key, value) => { mem.set(key, value); },
+    removeItem: (key) => { mem.delete(key); },
+  };
+}
+
+export function getSupabaseStorage(): StorageAdapter {
+  if (isLocalStorageUsable()) return window.localStorage;
+  // Safari Private mode often blocks quota for localStorage. Fallback to cookies, then memory.
+  try {
+    return cookieStorage();
+  } catch {
+    return memoryStorage();
+  }
+}


### PR DESCRIPTION
- src/lib/supabase/browser.ts: 브라우저 클라이언트를 싱글톤으로 유지하고, 커스텀 스토리지(쿠키/메모리 fallback)와 persistSession/autoRefreshToken 옵션을 적용해 사파 리 스토리지 차단에도 세션이 보존되도록 했습니다.
- src/lib/supabase/storage.ts: 사파리에서 localStorage가 막힐 때 쿠키 → 메모리 순으로 안전하게 대체하는 어댑터를 추가했습니다.
- src/lib/api.ts: API 호출 시 세션이 비어 있으면 refreshSession()을 한 번 더 시도해 Authorization 헤더를 채웁니다.
- src/app/components/Shell.tsx: 마운트 시 세션이 없을 때 한 번 더 refreshSession()을 시도해 사용자 정보를 불러오도록 했습니다.
- Fixes #20 